### PR TITLE
Support to Form properties when loading Lexicon from file

### DIFF
--- a/src/main/java/de/citec/sc/lemon/core/LexicalEntryWithResources.java
+++ b/src/main/java/de/citec/sc/lemon/core/LexicalEntryWithResources.java
@@ -1,29 +1,3 @@
-/**
- * ********************************************************************************
- * Copyright (c) 2016, Semantic Computing Group, Bielefeld University All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met: *
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer. * Redistributions in binary
- * form must reproduce the above copyright notice, this list of conditions and
- * the following disclaimer in the documentation and/or other materials provided
- * with the distribution. * Neither the name of the Semantic Computing Group nor the names
- * of its contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE MONNET PROJECT BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ********************************************************************************
- */
 package de.citec.sc.lemon.core;
 
 import java.util.HashSet;

--- a/src/main/java/de/citec/sc/lemon/core/LexicalEntryWithResources.java
+++ b/src/main/java/de/citec/sc/lemon/core/LexicalEntryWithResources.java
@@ -8,6 +8,7 @@ import org.apache.jena.rdf.model.Resource;
 /**
  * 
  * @author Alessandro Di Diego
+ * @author Giuseppe Vertulli
  */
 public class LexicalEntryWithResources extends LexicalEntry {
 

--- a/src/main/java/de/citec/sc/lemon/core/LexicalEntryWithResources.java
+++ b/src/main/java/de/citec/sc/lemon/core/LexicalEntryWithResources.java
@@ -1,0 +1,75 @@
+/**
+ * ********************************************************************************
+ * Copyright (c) 2016, Semantic Computing Group, Bielefeld University All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met: *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. * Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution. * Neither the name of the Semantic Computing Group nor the names
+ * of its contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE MONNET PROJECT BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ********************************************************************************
+ */
+package de.citec.sc.lemon.core;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.jena.rdf.model.Resource;
+
+/**
+ * 
+ * @author Alessandro Di Diego
+ */
+public class LexicalEntryWithResources extends LexicalEntry {
+
+	Resource canonicalFormResource;
+	Set<Resource> alternativeFormResources = new HashSet<Resource>();
+
+	public LexicalEntryWithResources(Language language) {
+		super(language);
+	}
+
+	public LexicalEntryWithResources(String uri, Language language) {
+		super(uri, language);
+	}
+
+	public Resource getCanonicalFormResource() {
+		return canonicalFormResource;
+	}
+
+	public void setCanonicalFormResource(Resource canonicalFormResource) {
+		this.canonicalFormResource = canonicalFormResource;
+	}
+
+	public Set<Resource> getAlternativeFormsResources() {
+		return alternativeFormResources;
+	}
+
+	public void setAlternativeFormsResources(Set<Resource> alternativeFormResources) {
+		this.alternativeFormResources = alternativeFormResources;
+	}
+	
+    public void addAlternativeFormsResource(Resource alternativeForm) {
+        this.alternativeFormResources.add(alternativeForm);
+    }
+    public void addAlternativeFormsAllResources(Set<Resource> alternativeForms) {
+        this.alternativeFormResources.addAll(alternativeForms);
+    }
+	
+
+}

--- a/src/main/java/de/citec/sc/lemon/core/LexiconWithResources.java
+++ b/src/main/java/de/citec/sc/lemon/core/LexiconWithResources.java
@@ -1,0 +1,76 @@
+package de.citec.sc.lemon.core;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * 
+ * @author Alessandro Di Diego
+ */
+public class LexiconWithResources extends Lexicon {
+
+	List<LexicalEntryWithResources> entriesWithResources;
+
+	public LexiconWithResources() {
+		super();
+		this.entriesWithResources = new ArrayList<>();
+	}
+
+	public LexiconWithResources(String baseURI) {
+		super(baseURI);
+		this.entriesWithResources = new ArrayList<>();
+	}
+
+	public List<LexicalEntryWithResources> getEntriesWithResources() {
+		return entriesWithResources;
+	}
+
+	private LexicalEntryWithResources getLexicalEntry(LexicalEntryWithResources entry) {
+		String uri = entry.getURI();
+		for (LexicalEntryWithResources containedEntry : entriesWithResources) {
+			if (containedEntry.getURI().equals(uri))
+				return containedEntry;
+		}
+		return null;
+	}
+
+	public void addEntry(LexicalEntryWithResources entry) {
+
+		if (!entriesWithResources.contains(entry)) {
+			entriesWithResources.add(entry);
+			entries.add(entry);
+		} else {
+			LexicalEntryWithResources containedEntry;
+
+			containedEntry = getLexicalEntry(entry);
+			// if entry of URI is the same, but different forms appear, add
+			// alternative forms
+			if (!containedEntry.getCanonicalFormResource().equals(entry.getCanonicalFormResource())) {
+				containedEntry.addAlternativeFormsResource(entry.getCanonicalFormResource());
+			}
+			if (!entry.getAlternativeFormsResources().isEmpty())
+				containedEntry.addAlternativeFormsAllResources(entry.getAlternativeFormsResources());
+
+			HashMap<Sense, HashSet<SyntacticBehaviour>> senseBehaviours = entry.getSenseBehaviours();
+			senseBehaviours.keySet().stream().map((sense) -> {
+				HashSet<SyntacticBehaviour> behaviours = senseBehaviours.get(sense);
+				containedEntry.addAllSyntacticBehaviour(behaviours, sense);
+				return sense;
+			}).forEach((sense) -> {
+
+				Provenance provenance = entry.getProvenance(sense);
+				containedEntry.addProvenance(provenance, sense);
+			});
+
+		}
+
+		if (entry.getSenseBehaviours() != null)
+			entry.getReferences().stream().forEach((reference) -> {
+				references.add(reference);
+			});
+
+	}
+
+}

--- a/src/main/java/de/citec/sc/lemon/core/LexiconWithResources.java
+++ b/src/main/java/de/citec/sc/lemon/core/LexiconWithResources.java
@@ -8,6 +8,7 @@ import java.util.List;
 /**
  * 
  * @author Alessandro Di Diego
+ * @author Giuseppe Vertulli
  */
 public class LexiconWithResources extends Lexicon {
 

--- a/src/main/java/de/citec/sc/lemon/io/LexiconLoader.java
+++ b/src/main/java/de/citec/sc/lemon/io/LexiconLoader.java
@@ -44,9 +44,7 @@ import org.apache.jena.vocabulary.RDF;
 
 import de.citec.sc.lemon.core.Language;
 
-import de.citec.sc.lemon.core.LexicalEntry;
 import de.citec.sc.lemon.core.LexicalEntryWithResources;
-import de.citec.sc.lemon.core.Lexicon;
 import de.citec.sc.lemon.core.LexiconWithResources;
 import de.citec.sc.lemon.core.Preposition;
 import de.citec.sc.lemon.core.Provenance;

--- a/src/main/java/de/citec/sc/lemon/vocabularies/LEXINFO.java
+++ b/src/main/java/de/citec/sc/lemon/vocabularies/LEXINFO.java
@@ -55,6 +55,8 @@ public class LEXINFO {
 	public static Property nounPossessiveFrame = defaultModel.createProperty("http://www.lexinfo.net/ontology/2.0/lexinfo#NounPossessiveFrame");
 	public static Property nounPredicateFrame = defaultModel.createProperty("http://www.lexinfo.net/ontology/2.0/lexinfo#NounPredicateFrame");
 	
-
+	public static Property number = defaultModel.createProperty("http://www.lexinfo.net/ontology/2.0/lexinfo#number");
+	public static Property tense = defaultModel.createProperty("http://www.lexinfo.net/ontology/2.0/lexinfo#tense");
+	public static Property degree = defaultModel.createProperty("http://www.lexinfo.net/ontology/2.0/lexinfo#degree");
 	
 }

--- a/src/main/java/de/citec/sc/lemon/vocabularies/LEXINFO.java
+++ b/src/main/java/de/citec/sc/lemon/vocabularies/LEXINFO.java
@@ -47,7 +47,7 @@ public class LEXINFO {
 	public static Property verb = defaultModel.createProperty("http://www.lexinfo.net/ontology/2.0/lexinfo#verb");
 	public static Property commonNoun = defaultModel.createProperty("http://www.lexinfo.net/ontology/2.0/lexinfo#commonNoun");
 	public static Property adjective = defaultModel.createProperty("http://www.lexinfo.net/ontology/2.0/lexinfo#adjective");
-        public static Property preposition = defaultModel.createProperty("http://www.lexinfo.net/ontology/2.0/lexinfo#preposition");
+    public static Property preposition = defaultModel.createProperty("http://www.lexinfo.net/ontology/2.0/lexinfo#preposition");
         
 	
 	public static Property transitiveFrame = defaultModel.createProperty("http://www.lexinfo.net/ontology/2.0/lexinfo#TransitiveFrame");


### PR DESCRIPTION
As now, the library it's unable to retrieve any property about the canonical Form and alternative Forms (otherForm). I've implemented a way to get the Resource object for Canonical form and Alternative forms maintaining retrocompatibility.

The solution I've used is not the cleanest solution (I've created two classes that extends LexicalEntry and Lexicon) and quite general, but maybe it could be useful.